### PR TITLE
feat: pass base URL and subscription key as input parameter in instance creation

### DIFF
--- a/signatureverifier/build.gradle
+++ b/signatureverifier/build.gradle
@@ -43,10 +43,6 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1"
-    implementation "androidx.security:security-crypto:1.1.0-alpha01"
-
-    kapt "io.github.rakutentech.manifestconfig:manifest-config-processor:0.2.0"
-    implementation "io.github.rakutentech.manifestconfig:manifest-config-annotations:0.2.0"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.4'

--- a/signatureverifier/src/main/kotlin/io/github/rakutentech/signatureverifier/RealSignatureVerifier.kt
+++ b/signatureverifier/src/main/kotlin/io/github/rakutentech/signatureverifier/RealSignatureVerifier.kt
@@ -1,8 +1,6 @@
 package io.github.rakutentech.signatureverifier
 
 import android.util.Base64
-import com.rakuten.tech.mobile.manifestconfig.annotations.ManifestConfig
-import com.rakuten.tech.mobile.manifestconfig.annotations.MetaData
 import io.github.rakutentech.signatureverifier.verification.PublicKeyCache
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -80,21 +78,5 @@ internal class RealSignatureVerifier(
 
         private const val UNCOMPRESSED_OFFSET = 1
         private const val POSITIVE_BIG_INTEGER = 1
-    }
-
-    @ManifestConfig
-    internal interface App {
-
-        /**
-         * Base URL for the Public Key API.
-         **/
-        @MetaData(key = "io.github.rakutentech.signatureverifier.RSVKeyFetchEndpoint")
-        fun baseUrl(): String
-
-        /**
-         * RAS Subscription Key for Public Key API.
-         **/
-        @MetaData(key = "io.github.rakutentech.signatureverifier.RASProjectSubscriptionKey")
-        fun subscriptionKey(): String
     }
 }

--- a/signatureverifier/src/main/kotlin/io/github/rakutentech/signatureverifier/SignatureVerifier.kt
+++ b/signatureverifier/src/main/kotlin/io/github/rakutentech/signatureverifier/SignatureVerifier.kt
@@ -24,7 +24,7 @@ abstract class SignatureVerifier {
         internal var callback: ((ex: Exception) -> Unit)? = null
 
         /**
-         * Initializes and instance of the Signature Verifiers SDK based on the provided parameters.
+         * Initializes an instance of the Signature Verifier SDK based on the provided parameters.
          *
          * @param [context] application context
          * @param [baseUrl] endpoint used for public key fetching

--- a/signatureverifier/src/main/kotlin/io/github/rakutentech/signatureverifier/api/ApiClient.kt
+++ b/signatureverifier/src/main/kotlin/io/github/rakutentech/signatureverifier/api/ApiClient.kt
@@ -10,6 +10,12 @@ import java.lang.IllegalArgumentException
 
 internal class ApiClient(baseUrl: String, subscriptionKey: String, context: Context) {
 
+    init {
+        if (subscriptionKey.isEmpty()) {
+            throw InvalidSignatureVerifierSubscriptionException()
+        }
+    }
+
     @Suppress("SpreadOperator")
     private val client = OkHttpClient.Builder()
         .cache(Cache(context.cacheDir,
@@ -49,9 +55,14 @@ internal class ApiClient(baseUrl: String, subscriptionKey: String, context: Cont
 }
 
 /**
- * Exception thrown when the value set in `AndroidManifest.xml` for
- * `io.github.rakutentech.signatureverifier.RSVKeyFetchEndpoint` is not a valid URL.
+ * Exception thrown when endpoint is not a valid URL.
  */
 class InvalidSignatureVerifierBaseUrlException(
     exception: IllegalArgumentException
 ) : IllegalArgumentException("An invalid URL was provided for the Signature Verifier base url.", exception)
+
+/**
+ * Exception thrown when subscription key is not a valid.
+ */
+class InvalidSignatureVerifierSubscriptionException :
+    IllegalArgumentException("An invalid value was provided for the Signature Verifier subscription key.")

--- a/signatureverifier/src/test/kotlin/io/github/rakutentech/signatureverifier/verification/PublicKeyCacheSpec.kt
+++ b/signatureverifier/src/test/kotlin/io/github/rakutentech/signatureverifier/verification/PublicKeyCacheSpec.kt
@@ -64,7 +64,7 @@ class PublicKeyCacheSpec : RobolectricBaseSpec() {
         When calling mockEncryptor.encrypt(any(), any()) itReturns null
         When calling mockFetcher.fetch(eq("test_key_id")) itThrows IOException("test")
 
-        cache["test_key_id"].shouldBeNull()
+        cache["test_key_id"].shouldBeEmpty()
         Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
         Mockito.verify(mockCallback).invoke(any(IOException::class))
     }

--- a/signatureverifier/src/test/kotlin/io/github/rakutentech/signatureverifier/verification/PublicKeyCacheSpec.kt
+++ b/signatureverifier/src/test/kotlin/io/github/rakutentech/signatureverifier/verification/PublicKeyCacheSpec.kt
@@ -64,7 +64,7 @@ class PublicKeyCacheSpec : RobolectricBaseSpec() {
         When calling mockEncryptor.encrypt(any(), any()) itReturns null
         When calling mockFetcher.fetch(eq("test_key_id")) itThrows IOException("test")
 
-        cache["test_key_id"].shouldBeEmpty()
+        cache["test_key_id"].shouldBeNull()
         Mockito.verify(mockFetcher).fetch(eq("test_key_id"))
         Mockito.verify(mockCallback).invoke(any(IOException::class))
     }


### PR DESCRIPTION
# Notes
compare to base branch (SDKCF-3920) for now to limit the changes, will compare and merge to `main` branch after merging [SDKCF-3920 PR](https://github.com/rakutentech/android-signatureverifier/pull/9)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have not committed any secrets (passwords, tokens, internal urls etc.) or sensitive information
- [x] I wrote/updated tests for new/changed code
- [x] I checked that all possible internal and platform/library exceptions are gracefully handled and **will not** crash the host app
- [x] I checked for open & known issues (especially crashes) for any newly added platform APIs or libraries
- [x] I tested non-trivial changes on a real device
- [x] I ran `./gradlew check` without errors
